### PR TITLE
Remove forcing bool for strbool function

### DIFF
--- a/includes/class-postmark-debug.php
+++ b/includes/class-postmark-debug.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Postmark_Debug' ) ) {
 		 * @param  bool $value  Value.
 		 * @return string Yes or No based on boolean provided.
 		 */
-		private function strbool( bool $value ) {
+		private function strbool( $value ) {
 			return $value ? 'Yes' : 'No';
 		}
 


### PR DESCRIPTION
@pgraham3 Based on the errors it seems somehow those sites did not have a value in their settings. Based on the errors, it  appears the helper function in the class requiring a boolval caused the error as it received "null". I removed the forcing of the helper function requiring a bool, maybe we can get one of these users to test.  Ideally we should have checks in place so that the setting is always saved in the options table properly. I know there is a reported issues to switch away from JSON so this might be a good opportunity for that. Should be fix for #95 