### PR TITLE
Use new Postmark Status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the ActiveCampaign Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
-## [1.18.0]
-- Add support for tags.
+## [1.18.1]
+- Update Status tab to use new Postmark API.
+- Tested up to WordPress 6.2.
 
 --------
 

--- a/page-settings.php
+++ b/page-settings.php
@@ -186,7 +186,7 @@ wp_nonce_field( 'postmark_nonce' );
 		$pm_status = json_decode(
 			wp_remote_retrieve_body(
 				wp_remote_get(
-					'https://status.postmarkapp.com/api/1.0/status/',
+					'https://status.postmarkapp.com/api/v1/status',
 					array(
 						'headers' => array(
 							'Accept'       => 'application/json',
@@ -203,14 +203,14 @@ wp_nonce_field( 'postmark_nonce' );
 				<th><label>Status</label></th>
 
 				<td>
-					<?php echo $pm_status->status; ?>
+					<?php echo $pm_status->page->state; ?>
 				</td>
 			</tr>
 			<tr>
 				<th><label>Last Checked</label></th>
 				<td>
 				<?php
-					$unix_date   = gmdate( 'U', strtotime( $pm_status->lastCheckDate ) );
+					$unix_date   = gmdate( 'U', strtotime( $pm_status->page->updated_at ) );
 					$date_format = get_option( 'date_format' );
 					$time_format = get_option( 'time_format' );
 					echo wp_date( "{$date_format} {$time_format}", $unix_date );

--- a/postmark.php
+++ b/postmark.php
@@ -6,7 +6,7 @@
  * Version: 1.18.0
  * Requires PHP: 7.0
  * Requires at least: 5.3
- * Tested up to: 6.1
+ * Tested up to: 6.2
  * Author: Andrew Yates & Matt Gibbs
  */
 

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActiveCampaign Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through ActiveCampaign Postmark
- * Version: 1.18.0
+ * Version: 1.18.1
  * Requires PHP: 7.0
  * Requires at least: 5.3
  * Tested up to: 6.2
@@ -41,7 +41,7 @@ class Postmark_Mail {
 	 *
 	 * @var string
 	 */
-	public static $POSTMARK_VERSION = '1.18.0';
+	public static $POSTMARK_VERSION = '1.18.1';
 
 	/**
 	 * ActiveCampaign Postmark Plugin Directory.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: postmark, email, smtp, notifications, wp_mail, wildbit
 Requires PHP: 7.0
 Requires at least: 5.3
 Tested up to: 6.2
-Stable tag: 1.18.0
+Stable tag: 1.18.1
 
 The *officially-supported* ActiveCampaign Postmark plugin for Wordpress.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: andy7629, alexknowshtml, mgibbs189, jptoto, atheken, prileygraham,
 Tags: postmark, email, smtp, notifications, wp_mail, wildbit
 Requires PHP: 7.0
 Requires at least: 5.3
-Tested up to: 6.1
+Tested up to: 6.2
 Stable tag: 1.18.0
 
 The *officially-supported* ActiveCampaign Postmark plugin for Wordpress.

--- a/readme.txt
+++ b/readme.txt
@@ -129,8 +129,9 @@ At [ActiveCampaign](https://www.activecampaign.com/?utm_source=postmark&utm_medi
 1. ActiveCampaign Postmark WP Plugin Settings screen.
 
 == Changelog ==
-= v1.18.0 =
-* Add support for tags.
+= v1.18.1 =
+* Update Status tab to use new Postmark API.
+* Tested up to WordPress 6.2.
 
 --------
 


### PR DESCRIPTION
Previous Status API has been deprecated, causing no data to be shown in the Status tab:

<img width="565" alt="Screenshot 2023-03-21 at 9 35 40 AM" src="https://user-images.githubusercontent.com/16660335/226622840-31a9abe9-02c0-469c-9a43-d0a2f1859330.png">
