### PR TITLE
v1.19.0 - metadata support via filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0]
+- Support adding metadata to messages
+
+## [1.18.1]
+- Update Status tab to use new Postmark API.
+- Tested up to WordPress 6.2.
+
 ## [1.18.0]
 - Add support for tags.
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,8 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the ActiveCampaign Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
-## [1.18.1]
-- Update Status tab to use new Postmark API.
-- Tested up to WordPress 6.2.
+## [1.19.0]
+- Support adding metadata to messages
 
 --------
 

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActiveCampaign Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through ActiveCampaign Postmark
- * Version: 1.18.1
+ * Version: 1.19.0
  * Requires PHP: 7.0
  * Requires at least: 5.3
  * Tested up to: 6.2
@@ -41,7 +41,7 @@ class Postmark_Mail {
 	 *
 	 * @var string
 	 */
-	public static $POSTMARK_VERSION = '1.18.1';
+	public static $POSTMARK_VERSION = '1.19.0';
 
 	/**
 	 * ActiveCampaign Postmark Plugin Directory.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: postmark, email, smtp, notifications, wp_mail, wildbit
 Requires PHP: 7.0
 Requires at least: 5.3
 Tested up to: 6.2
-Stable tag: 1.18.1
+Stable tag: 1.19.0
 
 The *officially-supported* ActiveCampaign Postmark plugin for Wordpress.
 
@@ -129,9 +129,8 @@ At [ActiveCampaign](https://www.activecampaign.com/?utm_source=postmark&utm_medi
 1. ActiveCampaign Postmark WP Plugin Settings screen.
 
 == Changelog ==
-= v1.18.1 =
-* Update Status tab to use new Postmark API.
-* Tested up to WordPress 6.2.
+= v1.19.0 =
+* Support adding metadata to messages
 
 --------
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -231,6 +231,11 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		$body['Tag'] = apply_filters( 'postmark_tag', $body['Tag'] );
 	}
 
+	// Support using a filter to set metadata on a message
+	if ( has_filter( 'postmark_metadata' ) ) {
+		$body['Metadata'] = apply_filters( 'postmark_metadata', array() );
+	}
+
 	if ( 1 === (int) $settings['force_html'] || 'text/html' === $content_type || 1 === $track_opens ) {
 		$body['HtmlBody'] = $message;
 		// The user really, truly wants this sent as HTML, don't send it as text, too.


### PR DESCRIPTION
Adds support for [metadata](https://postmarkapp.com/support/article/1125-custom-metadata-faq) via `postmark_metadata` filter