### PR TITLE
[v1.19.1] Fix strpos warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.1]
+- Fix warning when logging sends with a null To address
+
 ## [1.19.0]
 - Support adding metadata to messages
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the ActiveCampaign Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
-## [1.19.0]
-- Support adding metadata to messages
+## [1.19.1]
+- Fix warning when logging sends with a null To address
 
 --------
 

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActiveCampaign Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through ActiveCampaign Postmark
- * Version: 1.19.0
+ * Version: 1.19.1
  * Requires PHP: 7.0
  * Requires at least: 5.3
  * Tested up to: 6.2
@@ -41,7 +41,7 @@ class Postmark_Mail {
 	 *
 	 * @var string
 	 */
-	public static $POSTMARK_VERSION = '1.19.0';
+	public static $POSTMARK_VERSION = '1.19.1';
 
 	/**
 	 * ActiveCampaign Postmark Plugin Directory.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: postmark, email, smtp, notifications, wp_mail, wildbit
 Requires PHP: 7.0
 Requires at least: 5.3
 Tested up to: 6.2
-Stable tag: 1.19.0
+Stable tag: 1.19.1
 
 The *officially-supported* ActiveCampaign Postmark plugin for Wordpress.
 
@@ -133,8 +133,8 @@ At [ActiveCampaign](https://www.activecampaign.com/?utm_source=postmark&utm_medi
 1. ActiveCampaign Postmark WP Plugin Settings screen.
 
 == Changelog ==
-= v1.19.0 =
-* Support adding metadata to messages
+= v1.19.1 =
+* Fix warning when logging sends with a null To address
 
 --------
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -297,7 +297,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		$to    = $body['To'];
 
 		// Only store the To address, not the To name.
-		if ( false !== strpos( $body['To'], '<' ) && false !== strpos( $to, '>' ) ) {
+		if ( ! empty( $body['To'] ) && ! empty( $to ) && false !== strpos( $body['To'], '<' ) && false !== strpos( $to, '>' ) ) {
 			$to = substr( $body['To'], strpos( $body['To'], '<' ), -1 );
 		}
 


### PR DESCRIPTION
If `null` is passed to `wp_mail()` for the first (`$to`) parameter, line 300 of wp_mail.php throws a warning that passing null to strpos is deprecated.